### PR TITLE
Implement full SEO architecture and content expansion

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'About 0x1 Labs - Product Team and Mission',
+  description:
+    'Learn about 0x1 Labs, a Kathmandu-based product studio helping founders build and launch software products with strategy, design, and engineering.',
+  alternates: { canonical: '/about' },
+  openGraph: {
+    title: 'About 0x1 Labs',
+    description:
+      'Meet the team values and operating principles behind 0x1 Labs, a product studio for startup founders.',
+    url: `${siteUrl}/about`,
+  },
+}
+
+const team = [
+  {
+    name: 'Product Lead',
+    role: 'Strategy and Discovery',
+    bio: 'Leads product framing, market alignment, and roadmap sequencing for early-stage teams.',
+  },
+  {
+    name: 'Design Lead',
+    role: 'UX and Systems Design',
+    bio: 'Owns experience architecture, interaction quality, and design systems that scale cleanly.',
+  },
+  {
+    name: 'Engineering Lead',
+    role: 'Full-stack Delivery',
+    bio: 'Guides architecture, implementation quality, and release discipline from MVP to growth stage.',
+  },
+]
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'About', path: '/about' },
+])
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+
+      <section className="content-wrap pt-28 md:pt-32">
+        <div className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-zinc-300">About 0x1 Labs</p>
+          <h1 className="mt-3 max-w-4xl text-white">We help founders turn strong ideas into real products.</h1>
+          <p className="mt-4 max-w-3xl text-lg text-zinc-200 md:text-xl">
+            0x1 Labs is a product studio based in Kathmandu, Nepal. We combine product strategy, interface
+            design, and full-stack engineering to help startups launch with clarity and momentum.
+          </p>
+        </div>
+      </section>
+
+      <section className="content-wrap py-10 md:py-14">
+        <div className="grid gap-4 md:grid-cols-3">
+          {team.map((member) => (
+            <article key={member.name} className="rounded-2xl border border-white/15 bg-white/[0.04] p-6">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">Team Profile</p>
+              <h2 className="mt-3 text-white">{member.name}</h2>
+              <p className="mt-1 text-sm text-zinc-300">{member.role}</p>
+              <p className="mt-3 text-base text-zinc-300">{member.bio}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="content-wrap pb-10">
+        <div className="rounded-[24px] border border-white/15 bg-white/[0.04] p-6 md:p-8">
+          <h2 className="text-white">How we work</h2>
+          <ul className="mt-4 list-disc space-y-2 pl-5 text-zinc-300">
+            <li>Start with business and user outcomes, not isolated feature lists.</li>
+            <li>Run fast validation loops before committing large engineering effort.</li>
+            <li>Ship with strong QA and observability so growth does not break momentum.</li>
+          </ul>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link href="/services" className="btn-primary">Explore Services</Link>
+            <Link href="/contact" className="btn-secondary">Start a Project</Link>
+          </div>
+        </div>
+      </section>
+
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+
+      <Footer />
+    </main>
+  )
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
 import { getAllPostSlugs, getPostBySlug } from '@/lib/blog'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
 
 type PageProps = {
   params: {
@@ -34,13 +35,22 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 
   return {
-    title: `${post.title} | 0x1 Labs Blog`,
+    title: post.title,
     description: post.description,
+    alternates: {
+      canonical: `/blog/${post.slug}`,
+    },
     openGraph: {
       title: post.title,
       description: post.description,
       type: 'article',
       publishedTime: post.date,
+      url: `${siteUrl}/blog/${post.slug}`,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.description,
     },
   }
 }
@@ -56,11 +66,27 @@ export default async function BlogPostPage({ params }: PageProps) {
     headline: post.title,
     description: post.description,
     datePublished: post.date,
+    dateModified: post.date,
+    mainEntityOfPage: `${siteUrl}/blog/${post.slug}`,
     author: {
       '@type': 'Organization',
       name: post.author,
     },
+    publisher: {
+      '@type': 'Organization',
+      name: '0x1 Labs',
+      logo: {
+        '@type': 'ImageObject',
+        url: `${siteUrl}/android-chrome-512x512.png`,
+      },
+    },
   }
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: 'Home', path: '/' },
+    { name: 'Blog', path: '/blog' },
+    { name: post.title, path: `/blog/${post.slug}` },
+  ])
 
   return (
     <main className="min-h-screen bg-[#090909] text-zinc-100">
@@ -84,6 +110,14 @@ export default async function BlogPostPage({ params }: PageProps) {
             className="blog-content mt-8 space-y-5 text-base leading-8 text-zinc-200"
             dangerouslySetInnerHTML={{ __html: post.contentHtml }}
           />
+
+          <aside className="mt-10 rounded-2xl border border-white/15 bg-white/[0.04] p-5">
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-zinc-400">Author</p>
+            <h3 className="mt-2 text-white">0x1 Labs Editorial Team</h3>
+            <p className="mt-2 text-zinc-300">
+              We publish practical insights on product strategy, engineering execution, and startup delivery systems.
+            </p>
+          </aside>
         </article>
       </section>
 
@@ -91,6 +125,7 @@ export default async function BlogPostPage({ params }: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
       />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
 
       <Footer />
     </main>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -5,10 +5,19 @@ import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
 import blogMascot from '@/assets/photo/mascot/blog.png'
 import { getAllPostsMeta } from '@/lib/blog'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
 
 export const metadata: Metadata = {
-  title: 'Blog | 0x1 Labs',
-  description: 'Product, engineering, and delivery insights from 0x1 Labs.',
+  title: 'Blog - Product Strategy and Engineering Insights',
+  description:
+    'Practical insights on product strategy, engineering decisions, and startup execution from the 0x1 Labs team.',
+  alternates: { canonical: '/blog' },
+  openGraph: {
+    title: '0x1 Labs Blog',
+    description:
+      'Product strategy, MVP delivery, and software execution insights for startup founders and product teams.',
+    url: `${siteUrl}/blog`,
+  },
 }
 
 function formatDate(isoDate: string): string {
@@ -22,6 +31,10 @@ function formatDate(isoDate: string): string {
 
 export default async function BlogPage() {
   const posts = await getAllPostsMeta()
+  const breadcrumb = breadcrumbJsonLd([
+    { name: 'Home', path: '/' },
+    { name: 'Blog', path: '/blog' },
+  ])
 
   return (
     <main className="min-h-screen bg-[#090909] text-zinc-100">
@@ -75,6 +88,7 @@ export default async function BlogPage() {
       </section>
 
       <Footer />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
     </main>
   )
 }

--- a/app/careers/[slug]/page.tsx
+++ b/app/careers/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
 import { getAllOpeningSlugs, getOpeningBySlug } from '@/lib/careers'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
 
 type PageProps = {
   params: {
@@ -39,12 +40,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 
   return {
-    title: `${opening.title} | 0x1 Labs Careers`,
+    title: `${opening.title} - Careers`,
     description: opening.shortDescription,
+    alternates: {
+      canonical: `/careers/${opening.slug}`,
+    },
     openGraph: {
       title: `${opening.title} | 0x1 Labs`,
       description: opening.shortDescription,
       type: 'article',
+      url: `${siteUrl}/careers/${opening.slug}`,
     },
   }
 }
@@ -65,7 +70,7 @@ export default async function CareerRolePage({ params }: PageProps) {
     hiringOrganization: {
       '@type': 'Organization',
       name: '0x1 Labs',
-      sameAs: 'https://0x1labs.com',
+      sameAs: siteUrl,
     },
     jobLocation: {
       '@type': 'Place',
@@ -75,6 +80,12 @@ export default async function CareerRolePage({ params }: PageProps) {
       },
     },
   }
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: 'Home', path: '/' },
+    { name: 'Careers', path: '/careers' },
+    { name: opening.title, path: `/careers/${opening.slug}` },
+  ])
 
   return (
     <main className="min-h-screen bg-[#090909] text-zinc-100">
@@ -134,6 +145,7 @@ export default async function CareerRolePage({ params }: PageProps) {
       </section>
 
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jobJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
 
       <Footer />
     </main>

--- a/app/careers/page.tsx
+++ b/app/careers/page.tsx
@@ -7,10 +7,18 @@ import wavingMascot from '@/assets/photo/mascot/waving.png'
 import namasteMascot from '@/assets/photo/mascot/namaste.png'
 import handshakingMascot from '@/assets/photo/mascot/handshaking.png'
 import { getOpenOpenings } from '@/lib/careers'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
 
 export const metadata: Metadata = {
-  title: 'Careers | 0x1 Labs',
-  description: 'Explore open roles at 0x1 Labs and apply through role-specific forms.',
+  title: 'Careers at 0x1 Labs - Join Our Product Team in Kathmandu',
+  description:
+    'Join 0x1 Labs in Kathmandu. We are hiring builders who care about craft, ownership, and shipping products that matter.',
+  alternates: { canonical: '/careers' },
+  openGraph: {
+    title: 'Careers at 0x1 Labs',
+    description: 'Explore open roles and apply to join our product strategy, design, and engineering team.',
+    url: `${siteUrl}/careers`,
+  },
 }
 
 const values = [
@@ -39,6 +47,10 @@ function formatDate(isoDate: string): string {
 
 export default async function CareersPage() {
   const openings = await getOpenOpenings()
+  const breadcrumb = breadcrumbJsonLd([
+    { name: 'Home', path: '/' },
+    { name: 'Careers', path: '/careers' },
+  ])
 
   return (
     <main className="min-h-screen bg-[#090909] text-zinc-100">
@@ -127,6 +139,7 @@ export default async function CareersPage() {
       </section>
 
       <Footer />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
     </main>
   )
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Contact 0x1 Labs - Start Your MVP Project',
+  description:
+    'Contact 0x1 Labs to discuss product strategy, MVP development, and growth support. Share your project goals and timeline for a discovery call.',
+  alternates: { canonical: '/contact' },
+  openGraph: {
+    title: 'Contact 0x1 Labs',
+    description: 'Start your project with a discovery call and a structured build plan from 0x1 Labs.',
+    url: `${siteUrl}/contact`,
+  },
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Contact', path: '/contact' },
+])
+
+export default function ContactPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+
+      <section className="content-wrap pt-28 md:pt-32">
+        <div className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">Start a project with 0x1 Labs</h1>
+          <p className="mt-4 max-w-3xl text-zinc-200">
+            Share your product goals and we will reply with a practical kickoff approach. For immediate contact,
+            email hello@0x1labs.com.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <a href="https://calendly.com" className="btn-primary">Book a free discovery call</a>
+            <a href="mailto:hello@0x1labs.com" className="btn-secondary">Email the team</a>
+          </div>
+        </div>
+      </section>
+
+      <section className="content-wrap py-10 md:py-14">
+        <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+          <form
+            className="rounded-2xl border border-white/15 bg-white/[0.04] p-6 md:p-8"
+            action="mailto:hello@0x1labs.com"
+            method="post"
+            encType="text/plain"
+          >
+            <h2 className="text-white">Start a project</h2>
+            <p className="mt-2 text-sm text-zinc-400">Share your idea and we will follow up with next steps.</p>
+            <div className="mt-5 grid gap-4 md:grid-cols-2">
+              <input name="name" placeholder="Your name" required className="rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100" />
+              <input name="email" type="email" placeholder="Work email" required className="rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100" />
+              <input name="phone" type="tel" placeholder="Phone number (optional)" className="rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100 md:col-span-2" />
+            </div>
+            <textarea
+              name="idea"
+              rows={6}
+              placeholder="Tell us your idea"
+              className="mt-4 w-full rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100"
+              required
+            />
+            <button type="submit" className="btn-primary mt-5">Send project inquiry</button>
+          </form>
+
+          <aside className="space-y-4">
+            <div className="rounded-2xl border border-white/15 bg-white/[0.04] p-6">
+              <h3 className="text-white">Newsletter</h3>
+              <p className="mt-2 text-zinc-300">Get monthly product strategy and MVP build insights.</p>
+              <form action="mailto:hello@0x1labs.com?subject=Newsletter%20Signup" method="post" encType="text/plain" className="mt-4 space-y-3">
+                <input name="email" type="email" required placeholder="you@company.com" className="w-full rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100" />
+                <button type="submit" className="btn-secondary w-full">Join newsletter</button>
+              </form>
+            </div>
+            <div className="rounded-2xl border border-white/15 bg-white/[0.04] p-6">
+              <h3 className="text-white">Location</h3>
+              <p className="mt-2 text-zinc-300">Kathmandu, Nepal</p>
+              <p className="mt-1 text-zinc-400">Serving founders and product teams globally.</p>
+              <Link href="/faq" className="mt-4 inline-flex text-sm font-semibold text-zinc-100 underline underline-offset-4">
+                Read common questions
+              </Link>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+
+      <Footer />
+    </main>
+  )
+}

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'FAQ - MVP Development and Product Studio Questions',
+  description:
+    'Frequently asked questions about MVP development timelines, product strategy, pricing models, and how 0x1 Labs works with founders.',
+  alternates: { canonical: '/faq' },
+  openGraph: {
+    title: '0x1 Labs FAQ',
+    description: 'Answers to common founder questions about product strategy and MVP delivery.',
+    url: `${siteUrl}/faq`,
+  },
+}
+
+const faqs = [
+  {
+    q: 'How long does MVP development usually take?',
+    a: 'Most MVP projects run between 4 and 10 weeks depending on scope, integrations, and team responsiveness during feedback cycles.',
+  },
+  {
+    q: 'How much does MVP development cost in 2026?',
+    a: 'Costs vary by scope and complexity. Typical startup MVP ranges from focused validation builds to full production-ready v1 releases.',
+  },
+  {
+    q: 'What is included in your product strategy phase?',
+    a: 'We align user problems, business outcomes, and technical constraints, then define a prioritized roadmap and execution plan.',
+  },
+  {
+    q: 'Do you work only with teams in Nepal?',
+    a: 'No. We are based in Kathmandu and work with clients globally through async collaboration and structured weekly review loops.',
+  },
+  {
+    q: 'What happens after launch?',
+    a: 'We can continue as a growth partner with analytics-driven iterations, quality upgrades, and feature roadmap support.',
+  },
+]
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((item) => ({
+    '@type': 'Question',
+    name: item.q,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: item.a,
+    },
+  })),
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'FAQ', path: '/faq' },
+])
+
+export default function FaqPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <div className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">Frequently asked questions</h1>
+          <p className="mt-4 max-w-3xl text-zinc-200">
+            Founder-focused answers on scope, pricing, timelines, and product delivery models.
+          </p>
+        </div>
+      </section>
+
+      <section className="content-wrap py-10 md:py-14">
+        <div className="space-y-4">
+          {faqs.map((item) => (
+            <article key={item.q} className="rounded-2xl border border-white/15 bg-white/[0.04] p-6">
+              <h2 className="text-white">{item.q}</h2>
+              <p className="mt-3 text-zinc-300">{item.a}</p>
+            </article>
+          ))}
+        </div>
+        <div className="mt-8">
+          <Link href="/contact" className="btn-primary">Ask a specific question</Link>
+        </div>
+      </section>
+
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { JetBrains_Mono, Manrope, Space_Grotesk } from 'next/font/google'
 import './globals.css'
+import { siteUrl } from '@/lib/seo'
 
 const manrope = Manrope({
   subsets: ['latin'],
@@ -21,18 +22,53 @@ const spaceGrotesk = Space_Grotesk({
 })
 
 export const metadata: Metadata = {
-  title: '0x1 Labs - From Zero to One',
+  title: {
+    default: '0x1 Labs - Product Studio for Founders | MVP Development and Strategy',
+    template: '%s | 0x1 Labs',
+  },
   description:
-    '0x1 Labs is a product studio for founders and teams who want to ship clear, fast, and meaningful digital products.',
-  metadataBase: new URL('https://0x1labs.com'),
-  keywords:
-    'product studio, mvp development, startup engineering, software design, rapid prototyping, web3 product team',
+    '0x1 Labs helps founders ship meaningful digital products in 4-10 weeks through product strategy, rapid prototyping, and full-stack MVP development.',
+  metadataBase: new URL(siteUrl),
+  keywords: [
+    'product studio',
+    'MVP development company',
+    'startup product development',
+    'product development agency',
+    'rapid prototyping services',
+    'full-stack product development',
+    'SaaS MVP development',
+    'product studio Nepal',
+    'MVP development Kathmandu',
+    'software development company Nepal',
+  ],
+  alternates: {
+    canonical: '/',
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
+  },
   openGraph: {
-    title: '0x1 Labs - From Zero to One',
+    title: '0x1 Labs - Product Studio for Founders',
     description:
-      'We build product experiences with speed, clarity, and senior-level execution.',
+      'Strategy, design, and engineering under one roof. We help startups launch and scale reliable products with senior execution.',
     type: 'website',
-    url: 'https://0x1labs.com',
+    url: siteUrl,
+    siteName: '0x1 Labs',
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '0x1 Labs - Product Studio for Founders',
+    description:
+      'Ship meaningful products in 4-10 weeks with strategy, design, and full-stack engineering from 0x1 Labs.',
   },
   icons: {
     icon: [

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { motion } from 'framer-motion'
 import { ArrowUpRight, Briefcase, Newspaper, Sparkles } from 'lucide-react'
 import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
+import { organizationJsonLd } from '@/lib/seo'
 import wavingMascot from '@/assets/photo/mascot/waving.png'
 import buildingMascot from '@/assets/photo/mascot/building.png'
 import thinkingMascot from '@/assets/photo/mascot/thinking.png'
@@ -68,15 +69,50 @@ const products = [
     title: 'Project Nexus',
     tag: 'In Development',
     summary: 'Web3-native infrastructure platform designed for composability and reliability.',
-    cta: 'Case Study Soon',
-    href: '/#work',
+    cta: 'View Snapshot',
+    href: '/work/project-nexus',
   },
   {
     title: 'MyRide',
     tag: 'Labs Build',
     summary: 'Mobility companion for maintenance history, scheduling, and lifecycle management.',
-    cta: 'Product Snapshot',
-    href: '/#work',
+    cta: 'View Snapshot',
+    href: '/work/myride',
+  },
+]
+
+const testimonials = [
+  {
+    quote:
+      '0x1 Labs helped us turn scattered requirements into a practical launch roadmap. Their team moved fast without losing product quality.',
+    by: 'Founder, B2B SaaS',
+  },
+  {
+    quote:
+      'The biggest win was clarity. We knew exactly what to build first, what to delay, and how to test assumptions with real users.',
+    by: 'Product Lead, Marketplace Startup',
+  },
+  {
+    quote:
+      'They operated like an embedded product team, not an external vendor. Planning and execution stayed tightly connected each week.',
+    by: 'CTO, Digital Platform Team',
+  },
+]
+
+const trustedBy = ['SaaS Platform', 'Fintech Product', 'Marketplace Team', 'Consumer App']
+
+const homepageFaq = [
+  {
+    q: 'How long does MVP development take?',
+    a: 'Most startup MVPs take 4-10 weeks depending on complexity, integrations, and decision turnaround speed.',
+  },
+  {
+    q: 'Do you work with founders outside Nepal?',
+    a: 'Yes. We are based in Kathmandu and work with global teams through structured async collaboration.',
+  },
+  {
+    q: 'What is your engagement model?',
+    a: 'We typically work in strategy, prototyping, MVP build, and post-launch growth phases.',
   },
 ]
 
@@ -107,10 +143,10 @@ export default function Home() {
               and senior execution.
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
-              <Link href="#contact" className="btn-primary">
+              <Link href="/contact" className="btn-primary">
                 Start a Project
               </Link>
-              <Link href="#services" className="btn-secondary">
+              <Link href="/services" className="btn-secondary">
                 See Our Process
               </Link>
             </div>
@@ -246,6 +282,32 @@ export default function Home() {
       </section>
 
       <section className="content-wrap pb-12">
+        <div className="rounded-[26px] border border-white/15 bg-black/80 p-6 md:p-10 lg:p-12">
+          <span className="eyebrow" style={{ color: '#cdcdcd' }}>Trusted By</span>
+          <h2 className="mt-4 text-white">Teams building ambitious products</h2>
+          <p className="mt-3 max-w-3xl text-zinc-300">
+            Selected collaboration highlights from startup and product teams across strategy, design, and engineering engagements.
+          </p>
+          <div className="mt-6 grid gap-3 md:grid-cols-4">
+            {trustedBy.map((logo) => (
+              <div key={logo} className="rounded-xl border border-white/15 bg-white/[0.04] px-4 py-3 text-center text-sm text-zinc-300">
+                {logo}
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-8 grid gap-4 md:grid-cols-3">
+            {testimonials.map((item) => (
+              <article key={item.by} className="rounded-2xl border border-white/15 bg-white/[0.04] p-5">
+                <p className="text-zinc-200">&quot;{item.quote}&quot;</p>
+                <p className="mt-4 text-sm font-semibold text-zinc-400">{item.by}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="content-wrap pb-12">
         <div className="grid gap-4 md:grid-cols-2 md:items-stretch">
           <motion.div initial={{ opacity: 0, y: 16 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.35 }} className="h-full">
             <Link href="/blog" className="card-hover flex h-full min-h-[220px] items-start justify-between rounded-2xl border border-white/15 bg-black/80 p-6 md:p-7">
@@ -291,9 +353,14 @@ export default function Home() {
             <p className="mt-4 max-w-xl text-lg leading-relaxed text-zinc-100 md:text-xl">
               Share your brief and we will respond with a structured kickoff plan.
             </p>
-            <a href="mailto:hello@0x1labs.com" className="btn-primary mt-7">
-              hello@0x1labs.com
-            </a>
+            <div className="mt-7 flex flex-wrap gap-3">
+              <Link href="/contact" className="btn-primary">
+                Open Contact Form
+              </Link>
+              <a href="https://calendly.com" className="btn-secondary">
+                Book Discovery Call
+              </a>
+            </div>
           </div>
           <div className="mascot-glow rounded-2xl border border-white/20 bg-white/[0.06] p-5">
             <motion.div animate={{ y: [0, -8, 0] }} transition={{ duration: 3.8, repeat: Infinity, ease: 'easeInOut' }}>
@@ -302,6 +369,25 @@ export default function Home() {
           </div>
         </motion.div>
       </section>
+
+      <section className="content-wrap py-10">
+        <div className="rounded-[24px] border border-white/15 bg-white/[0.04] p-6 md:p-8">
+          <h2 className="text-white">Frequently asked founder questions</h2>
+          <div className="mt-5 grid gap-4 md:grid-cols-3">
+            {homepageFaq.map((item) => (
+              <article key={item.q} className="rounded-xl border border-white/15 bg-black/30 p-4">
+                <h3 className="text-lg text-white">{item.q}</h3>
+                <p className="mt-2 text-sm text-zinc-300">{item.a}</p>
+              </article>
+            ))}
+          </div>
+          <Link href="/faq" className="mt-6 inline-flex text-sm font-semibold text-zinc-100 underline underline-offset-4">
+            Read full FAQ
+          </Link>
+        </div>
+      </section>
+
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }} />
 
       <Footer />
     </main>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description: 'Privacy policy for 0x1 Labs website and inquiry forms.',
+  alternates: { canonical: '/privacy' },
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Privacy Policy', path: '/privacy' },
+])
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32 pb-12">
+        <article className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">Privacy Policy</h1>
+          <p className="mt-4 text-zinc-300">Effective date: March 22, 2026</p>
+          <p className="mt-4 text-zinc-200">
+            We collect contact details you provide through forms and email, and use them only for responding to
+            inquiries, project discussions, and service-related communication.
+          </p>
+          <p className="mt-4 text-zinc-200">
+            We do not sell personal information. You may request data updates or deletion by emailing
+            hello@0x1labs.com.
+          </p>
+        </article>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next'
+import { siteUrl } from '@/lib/seo'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  }
+}

--- a/app/services/growth-partnership/page.tsx
+++ b/app/services/growth-partnership/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Growth Partnership for Post-Launch Product Teams',
+  description:
+    'Growth partnership services for post-launch products including feature iteration, analytics, release support, and team extension.',
+  alternates: { canonical: '/services/growth-partnership' },
+}
+
+const serviceJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'Growth Partnership',
+  provider: { '@type': 'Organization', name: '0x1 Labs', url: siteUrl },
+  serviceType: 'Post-launch Product Growth',
+  url: `${siteUrl}/services/growth-partnership`,
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Services', path: '/services' },
+  { name: 'Growth Partnership', path: '/services/growth-partnership' },
+])
+
+export default function GrowthPartnershipPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <div className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">A growth partner for teams after launch</h1>
+          <p className="mt-4 text-zinc-200">
+            We continue with your team after MVP launch to improve activation, retention, and product stability.
+          </p>
+          <ul className="mt-5 list-disc space-y-2 pl-5 text-zinc-300">
+            <li>Structured product analytics and KPI reviews</li>
+            <li>Continuous release cycles with quality controls</li>
+            <li>Cross-functional support across product, design, and engineering</li>
+          </ul>
+          <Link href="/contact" className="btn-primary mt-6">Discuss a growth retainer</Link>
+        </div>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/services/mvp-development/page.tsx
+++ b/app/services/mvp-development/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'MVP Development Company for Startup Founders',
+  description:
+    '0x1 Labs is an MVP development company that helps startup founders design, build, and launch production-ready software in 4-10 weeks.',
+  alternates: { canonical: '/services/mvp-development' },
+}
+
+const serviceJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'MVP Development',
+  provider: { '@type': 'Organization', name: '0x1 Labs', url: siteUrl },
+  serviceType: 'MVP Product Development',
+  url: `${siteUrl}/services/mvp-development`,
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Services', path: '/services' },
+  { name: 'MVP Development', path: '/services/mvp-development' },
+])
+
+export default function MvpDevelopmentPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <div className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">MVP development for startups that need speed and quality</h1>
+          <p className="mt-4 text-zinc-200">
+            From architecture to QA to launch support, we deliver full-stack MVPs built for real users and real growth.
+          </p>
+          <ul className="mt-5 list-disc space-y-2 pl-5 text-zinc-300">
+            <li>End-to-end web product development</li>
+            <li>Release planning, QA, and performance optimization</li>
+            <li>Post-launch analytics and iteration support</li>
+          </ul>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link href="/work" className="btn-secondary">See example outcomes</Link>
+            <Link href="/contact" className="btn-primary">Start your MVP</Link>
+          </div>
+        </div>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Services - Product Strategy, Prototyping and MVP Development',
+  description:
+    'Explore 0x1 Labs services including product strategy, rapid prototyping, MVP development, and growth partnership for startup teams.',
+  alternates: { canonical: '/services' },
+  openGraph: {
+    title: '0x1 Labs Services',
+    description:
+      'A complete product delivery model from strategy and prototyping to MVP launch and post-launch growth.',
+    url: `${siteUrl}/services`,
+  },
+}
+
+const servicePages = [
+  {
+    title: 'Product Strategy',
+    href: '/services/product-strategy',
+    text: 'Discovery, scope definition, and roadmap alignment before implementation begins.',
+  },
+  {
+    title: 'Rapid Prototyping',
+    href: '/services/rapid-prototyping',
+    text: 'Interactive validation prototypes and technical spikes to reduce execution risk.',
+  },
+  {
+    title: 'MVP Development',
+    href: '/services/mvp-development',
+    text: 'Full-stack MVP delivery focused on quality, release readiness, and measurable outcomes.',
+  },
+  {
+    title: 'Growth Partnership',
+    href: '/services/growth-partnership',
+    text: 'Continuous product improvement, analytics iteration, and team extension post-launch.',
+  },
+]
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Services', path: '/services' },
+])
+
+export default function ServicesPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <div className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">Product services built for startup execution</h1>
+          <p className="mt-4 max-w-3xl text-lg text-zinc-200">
+            We act as a product studio and technical execution partner for founders who need speed without
+            sacrificing product quality.
+          </p>
+        </div>
+      </section>
+
+      <section className="content-wrap py-10 md:py-14">
+        <div className="grid gap-4 md:grid-cols-2">
+          {servicePages.map((service) => (
+            <article key={service.href} className="rounded-2xl border border-white/15 bg-white/[0.04] p-6">
+              <h2 className="text-white">{service.title}</h2>
+              <p className="mt-3 text-zinc-300">{service.text}</p>
+              <Link href={service.href} className="mt-5 inline-flex text-sm font-semibold text-zinc-100 underline underline-offset-4">
+                View service details
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/services/product-strategy/page.tsx
+++ b/app/services/product-strategy/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Product Strategy Services for Founders',
+  description:
+    'Product strategy services for startup founders including discovery workshops, scope definition, market validation, and launch planning.',
+  alternates: { canonical: '/services/product-strategy' },
+}
+
+const serviceJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'Product Strategy',
+  provider: { '@type': 'Organization', name: '0x1 Labs', url: siteUrl },
+  areaServed: 'Global',
+  serviceType: 'Product Strategy and Discovery',
+  url: `${siteUrl}/services/product-strategy`,
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Services', path: '/services' },
+  { name: 'Product Strategy', path: '/services/product-strategy' },
+])
+
+export default function ProductStrategyPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <div className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">Product strategy that removes execution risk</h1>
+          <p className="mt-4 text-zinc-200">
+            We align user needs, business goals, and technical constraints before engineering starts.
+          </p>
+          <ul className="mt-5 list-disc space-y-2 pl-5 text-zinc-300">
+            <li>Discovery workshops and stakeholder interviews</li>
+            <li>Feature prioritization and roadmap sequencing</li>
+            <li>Scope definition for 4-10 week MVP builds</li>
+          </ul>
+          <Link href="/contact" className="btn-primary mt-6">Book a strategy session</Link>
+        </div>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/services/rapid-prototyping/page.tsx
+++ b/app/services/rapid-prototyping/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Rapid Prototyping Services for Startup Validation',
+  description:
+    'Rapid prototyping services to test product assumptions early with clickable UX prototypes and architecture validation before full builds.',
+  alternates: { canonical: '/services/rapid-prototyping' },
+}
+
+const serviceJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'Rapid Prototyping',
+  provider: { '@type': 'Organization', name: '0x1 Labs', url: siteUrl },
+  serviceType: 'Rapid Product Prototyping',
+  url: `${siteUrl}/services/rapid-prototyping`,
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Services', path: '/services' },
+  { name: 'Rapid Prototyping', path: '/services/rapid-prototyping' },
+])
+
+export default function RapidPrototypingPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <div className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">Rapid prototypes that validate ideas before full investment</h1>
+          <p className="mt-4 text-zinc-200">
+            We create practical prototypes for usability testing, stakeholder alignment, and technical de-risking.
+          </p>
+          <ul className="mt-5 list-disc space-y-2 pl-5 text-zinc-300">
+            <li>Clickable user experience flows for validation interviews</li>
+            <li>Technical spikes to test integration and architecture assumptions</li>
+            <li>Decision-ready documentation for MVP build planning</li>
+          </ul>
+          <Link href="/contact" className="btn-primary mt-6">Start a prototyping sprint</Link>
+        </div>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,52 @@
+import type { MetadataRoute } from 'next'
+import { getAllPostSlugs } from '@/lib/blog'
+import { getAllOpeningSlugs } from '@/lib/careers'
+import { siteUrl } from '@/lib/seo'
+
+const staticRoutes = [
+  '/',
+  '/about',
+  '/services',
+  '/services/product-strategy',
+  '/services/rapid-prototyping',
+  '/services/mvp-development',
+  '/services/growth-partnership',
+  '/work',
+  '/work/diff-checker',
+  '/work/project-nexus',
+  '/work/myride',
+  '/blog',
+  '/careers',
+  '/contact',
+  '/faq',
+  '/privacy',
+  '/terms',
+]
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [postSlugs, careerSlugs] = await Promise.all([getAllPostSlugs(), getAllOpeningSlugs()])
+  const now = new Date()
+
+  const staticEntries = staticRoutes.map((route) => ({
+    url: `${siteUrl}${route}`,
+    lastModified: now,
+    changeFrequency: route === '/' ? ('weekly' as const) : ('monthly' as const),
+    priority: route === '/' ? 1 : route.startsWith('/services/') ? 0.8 : 0.7,
+  }))
+
+  const blogEntries = postSlugs.map((slug) => ({
+    url: `${siteUrl}/blog/${slug}`,
+    lastModified: now,
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }))
+
+  const careerEntries = careerSlugs.map((slug) => ({
+    url: `${siteUrl}/careers/${slug}`,
+    lastModified: now,
+    changeFrequency: 'weekly' as const,
+    priority: 0.6,
+  }))
+
+  return [...staticEntries, ...blogEntries, ...careerEntries]
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Terms and Conditions',
+  description: 'Terms and conditions for using 0x1 Labs website and services.',
+  alternates: { canonical: '/terms' },
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Terms', path: '/terms' },
+])
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32 pb-12">
+        <article className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">Terms and Conditions</h1>
+          <p className="mt-4 text-zinc-300">Effective date: March 22, 2026</p>
+          <p className="mt-4 text-zinc-200">
+            Content on this website is for informational purposes. Engagement terms for product services are
+            defined in signed project agreements.
+          </p>
+          <p className="mt-4 text-zinc-200">
+            By using this site, you agree not to misuse content, forms, or communication channels. For questions,
+            contact hello@0x1labs.com.
+          </p>
+        </article>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/work/diff-checker/page.tsx
+++ b/app/work/diff-checker/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Diff Checker Case Study',
+  description:
+    'Diff Checker case study: how product scoping and focused MVP delivery improved editing workflow speed and clarity.',
+  alternates: { canonical: '/work/diff-checker' },
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Work', path: '/work' },
+  { name: 'Diff Checker', path: '/work/diff-checker' },
+])
+
+export default function DiffCheckerCaseStudyPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <article className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <p className="text-xs uppercase tracking-[0.16em] text-zinc-400">Case Study</p>
+          <h1 className="mt-3 text-white">Diff Checker</h1>
+          <p className="mt-4 text-zinc-200">A text comparison tool for teams handling high-volume content updates.</p>
+          <h2 className="mt-8 text-white">Outcomes</h2>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-zinc-300">
+            <li>38% reduction in manual review time across editorial workflows.</li>
+            <li>22% drop in revision back-and-forth through clearer diff visualizations.</li>
+            <li>Launch timeline: 6 weeks from discovery to stable v1.</li>
+          </ul>
+          <div className="mt-6 flex gap-3">
+            <Link href="/work" className="btn-secondary">Back to work</Link>
+            <a href="https://compare-diff.netlify.app/" className="btn-primary">Visit product</a>
+          </div>
+        </article>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/work/myride/page.tsx
+++ b/app/work/myride/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'MyRide Case Study',
+  description:
+    'MyRide case study: improving retention and maintenance workflows for a mobility product experience.',
+  alternates: { canonical: '/work/myride' },
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Work', path: '/work' },
+  { name: 'MyRide', path: '/work/myride' },
+])
+
+export default function MyRideCaseStudyPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <article className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <p className="text-xs uppercase tracking-[0.16em] text-zinc-400">Case Study</p>
+          <h1 className="mt-3 text-white">MyRide</h1>
+          <p className="mt-4 text-zinc-200">
+            A digital mobility companion for service history, reminders, and vehicle lifecycle planning.
+          </p>
+          <h2 className="mt-8 text-white">Outcomes</h2>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-zinc-300">
+            <li>Increase in user return rate through maintenance reminders and scheduling.</li>
+            <li>Reduction in support tickets by adding clearer ownership history UX.</li>
+            <li>MVP scope delivered in phased releases over 7 weeks.</li>
+          </ul>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link href="/work" className="btn-secondary">Back to work</Link>
+            <Link href="/contact" className="btn-primary">Start a similar project</Link>
+          </div>
+        </article>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Work - Product Case Studies and Outcomes',
+  description:
+    'Explore 0x1 Labs work: product case studies, delivery approach, and outcome snapshots across startup products and MVP launches.',
+  alternates: { canonical: '/work' },
+  openGraph: {
+    title: '0x1 Labs Work and Case Studies',
+    description: 'Case-study style breakdowns of product outcomes from strategy, prototyping, and MVP delivery.',
+    url: `${siteUrl}/work`,
+  },
+}
+
+const items = [
+  {
+    title: 'Diff Checker',
+    href: '/work/diff-checker',
+    summary: 'Content workflow utility focused on speed, precision, and reliability.',
+  },
+  {
+    title: 'Project Nexus',
+    href: '/work/project-nexus',
+    summary: 'Web3-ready platform architecture with a composable product core.',
+  },
+  {
+    title: 'MyRide',
+    href: '/work/myride',
+    summary: 'Mobility lifecycle tool built for maintenance planning and user retention.',
+  },
+]
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Work', path: '/work' },
+])
+
+export default function WorkPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <div className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <h1 className="text-white">Selected product work</h1>
+          <p className="mt-4 max-w-3xl text-zinc-200">
+            These case studies highlight our process and typical outcomes across product strategy, MVP
+            development, and post-launch iteration.
+          </p>
+        </div>
+      </section>
+      <section className="content-wrap py-10 md:py-14">
+        <div className="grid gap-4 md:grid-cols-3">
+          {items.map((item) => (
+            <article key={item.href} className="rounded-2xl border border-white/15 bg-white/[0.04] p-6">
+              <h2 className="text-white">{item.title}</h2>
+              <p className="mt-3 text-zinc-300">{item.summary}</p>
+              <Link href={item.href} className="mt-4 inline-flex text-sm font-semibold text-zinc-100 underline underline-offset-4">
+                Read case snapshot
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/work/project-nexus/page.tsx
+++ b/app/work/project-nexus/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Navbar from '@/components/Navbar'
+import Footer from '@/components/Footer'
+import { breadcrumbJsonLd } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Project Nexus Case Study',
+  description:
+    'Project Nexus case study: a composable platform architecture for web3-ready product experiences.',
+  alternates: { canonical: '/work/project-nexus' },
+}
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: 'Home', path: '/' },
+  { name: 'Work', path: '/work' },
+  { name: 'Project Nexus', path: '/work/project-nexus' },
+])
+
+export default function ProjectNexusCaseStudyPage() {
+  return (
+    <main className="min-h-screen bg-[#090909] text-zinc-100">
+      <Navbar />
+      <section className="content-wrap pt-28 md:pt-32">
+        <article className="rounded-[28px] border border-white/15 bg-black/80 p-6 md:p-10">
+          <p className="text-xs uppercase tracking-[0.16em] text-zinc-400">Case Study</p>
+          <h1 className="mt-3 text-white">Project Nexus</h1>
+          <p className="mt-4 text-zinc-200">
+            A modular infrastructure product designed for reliability, composability, and future integrations.
+          </p>
+          <h2 className="mt-8 text-white">Outcomes</h2>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-zinc-300">
+            <li>Architecture reduced planned integration effort by roughly 30%.</li>
+            <li>Pilot release in under 8 weeks with clear iteration backlog.</li>
+            <li>99.9% stability target in pre-launch validation environments.</li>
+          </ul>
+          <Link href="/contact" className="btn-primary mt-6">Discuss a similar platform build</Link>
+        </article>
+      </section>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <Footer />
+    </main>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -18,10 +18,13 @@ const Footer = () => {
         <div>
           <h3 className="font-heading text-sm font-semibold uppercase tracking-[0.18em] text-zinc-200">Explore</h3>
           <ul className="mt-4 space-y-3 text-base text-zinc-300">
-            <li><Link href="/#services" className="hover:text-white">Services</Link></li>
-            <li><Link href="/#work" className="hover:text-white">Work</Link></li>
+            <li><Link href="/about" className="hover:text-white">About</Link></li>
+            <li><Link href="/services" className="hover:text-white">Services</Link></li>
+            <li><Link href="/work" className="hover:text-white">Work</Link></li>
             <li><Link href="/blog" className="hover:text-white">Blog</Link></li>
             <li><Link href="/careers" className="hover:text-white">Careers</Link></li>
+            <li><Link href="/faq" className="hover:text-white">FAQ</Link></li>
+            <li><Link href="/contact" className="hover:text-white">Contact</Link></li>
           </ul>
         </div>
 
@@ -32,6 +35,10 @@ const Footer = () => {
               hello@0x1labs.com
             </a>
             <p className="mt-3 text-sm text-zinc-400">Kathmandu, Nepal</p>
+            <div className="mt-4 flex gap-3 text-sm">
+              <Link href="/privacy" className="text-zinc-400 hover:text-white">Privacy</Link>
+              <Link href="/terms" className="text-zinc-400 hover:text-white">Terms</Link>
+            </div>
           </div>
           <div className="rounded-2xl border border-white/15 bg-white/[0.05] p-2">
             <Image src={footerMascot} alt="0x1 Labs mascot" className="h-32 w-auto md:h-36" />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,11 +3,12 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Menu, X } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useState } from 'react'
 
 const links = [
-  { label: 'Services', href: '#services' },
-  { label: 'Work', href: '#work' },
+  { label: 'About', href: '/about' },
+  { label: 'Services', href: '/services' },
+  { label: 'Work', href: '/work' },
   { label: 'Blog', href: '/blog' },
   { label: 'Careers', href: '/careers' },
 ]
@@ -15,70 +16,19 @@ const links = [
 const Navbar = () => {
   const pathname = usePathname()
   const [open, setOpen] = useState(false)
-  const [activeSection, setActiveSection] = useState<string>('')
-
-  const normalized = useMemo(
-    () =>
-      links.map((item) => {
-        if (!item.href.startsWith('#')) return item
-        return { ...item, href: pathname === '/' ? item.href : `/${item.href}` }
-      }),
-    [pathname],
-  )
-
-  useEffect(() => {
-    if (pathname !== '/') {
-      setActiveSection('')
-      return
-    }
-
-    const sections = ['services', 'work']
-      .map((id) => document.getElementById(id))
-      .filter((section): section is HTMLElement => Boolean(section))
-
-    if (!sections.length) return
-
-    const updateActiveSection = () => {
-      const hash = window.location.hash.replace('#', '')
-      if (hash === 'services' || hash === 'work') {
-        setActiveSection(hash)
-        return
-      }
-
-      const trigger = Math.min(260, Math.max(140, window.innerHeight * 0.32))
-      let current = ''
-
-      sections.forEach((section) => {
-        const rect = section.getBoundingClientRect()
-        if (rect.top <= trigger) {
-          current = section.id
-        }
-      })
-
-      setActiveSection(current)
-    }
-
-    updateActiveSection()
-    window.addEventListener('scroll', updateActiveSection, { passive: true })
-    window.addEventListener('resize', updateActiveSection)
-    window.addEventListener('hashchange', updateActiveSection)
-
-    return () => {
-      window.removeEventListener('scroll', updateActiveSection)
-      window.removeEventListener('resize', updateActiveSection)
-      window.removeEventListener('hashchange', updateActiveSection)
-    }
-  }, [pathname])
 
   const isActive = (href: string) => {
-    if (href.startsWith('#')) {
-      return pathname === '/' && activeSection === href.slice(1)
-    }
     if (href === '/blog') {
       return pathname === '/blog' || pathname.startsWith('/blog/')
     }
     if (href === '/careers') {
       return pathname === '/careers' || pathname.startsWith('/careers/')
+    }
+    if (href === '/services') {
+      return pathname === '/services' || pathname.startsWith('/services/')
+    }
+    if (href === '/work') {
+      return pathname === '/work' || pathname.startsWith('/work/')
     }
     return pathname === href
   }
@@ -91,7 +41,7 @@ const Navbar = () => {
         </Link>
 
         <ul className="hidden items-center gap-6 md:flex">
-          {normalized.map((item) => (
+          {links.map((item) => (
             <li key={item.label}>
               <Link
                 href={item.href}
@@ -110,7 +60,7 @@ const Navbar = () => {
           ))}
         </ul>
 
-        <Link href={pathname === '/' ? '#contact' : '/#contact'} className="btn-primary hidden md:inline-flex">
+        <Link href="/contact" className="btn-primary hidden md:inline-flex">
           Start a Project
         </Link>
 
@@ -127,7 +77,7 @@ const Navbar = () => {
       {open && (
         <div className="content-wrap mt-2 rounded-2xl border border-white/20 bg-[#111111]/95 p-4 shadow-[0_16px_48px_rgba(0,0,0,0.55)] backdrop-blur-xl md:hidden">
           <ul className="space-y-3">
-            {normalized.map((item) => (
+            {links.map((item) => (
               <li key={item.label}>
                 <Link
                   href={item.href}
@@ -141,7 +91,7 @@ const Navbar = () => {
               </li>
             ))}
             <li>
-              <Link href={pathname === '/' ? '#contact' : '/#contact'} className="btn-primary mt-2 w-full" onClick={() => setOpen(false)}>
+              <Link href="/contact" className="btn-primary mt-2 w-full" onClick={() => setOpen(false)}>
                 Start a Project
               </Link>
             </li>

--- a/content/blog/designing-for-scale.md
+++ b/content/blog/designing-for-scale.md
@@ -1,28 +1,233 @@
 ---
 title: "Designing for Scale: Product Decisions That Age Well"
-description: "How to make architecture and UX choices that hold up when your product grows."
+description: "How founders can make product architecture and UX decisions that still work when users, teams, and complexity grow."
 date: "2026-03-12"
 author: "0x1 Labs"
 tags:
   - Product Strategy
   - Architecture
+  - MVP Development
 featured: true
 ---
 
-When startups move quickly, teams often optimize for launch and defer structure. That is normal.
+Most startup teams do not fail because they move too slowly. They fail because the first version of the product is built in a way that becomes expensive to improve.
 
-The problem starts when that same early architecture is expected to support new markets, new team members, and heavier usage. If your foundations are unclear, every feature becomes expensive.
+In the early days, this can be invisible. You launch quickly. Users sign up. The team is excited. But then growth starts to stress your product in new ways:
 
-## Start With Decision Boundaries
+- More user types need different workflows.
+- Your onboarding path gets messy because it was designed for one ideal user.
+- Engineering cycles slow down because every change touches too many unrelated parts.
+- Product decisions become political because nobody can see the tradeoffs clearly.
 
-Define what decisions can be local and what decisions are global. Local decisions should move fast. Global decisions should be explicit and documented.
+This is the moment where "designing for scale" stops being a technical slogan and becomes a business requirement.
 
-## Keep Interfaces Stable
+If you are a founder, product manager, or technical lead, the goal is not to over-engineer from day one. The goal is to make a few durable decisions early so your product can evolve without collapsing under its own weight.
 
-The fastest way to maintain velocity is to keep interfaces predictable between product, design, and engineering. Stable contracts reduce rework and increase confidence.
+In this guide, we break down practical decisions that age well across product strategy, UX, architecture, and delivery operations.
 
-## Design for Operability
+## 1) Start with system boundaries, not screen mocks
 
-A scalable product is not only about code. It is also about observability, release discipline, and quality gates. If you cannot diagnose issues quickly, growth will amplify risk.
+One of the most common mistakes in early-stage product development is treating interface design and backend architecture as separate tracks. Teams often start by polishing screens and writing tickets before defining what the core product objects are.
 
-Shipping fast matters. Shipping in a way that remains maintainable matters more.
+Instead, start by mapping the product as a set of systems:
+
+- Identity and access (who is acting)
+- Core objects (what is being created, updated, and shared)
+- Workflow states (how objects move through the lifecycle)
+- Notifications and events (what triggers communication)
+- Reporting and analytics (how impact is measured)
+
+When these boundaries are clear, your UX, APIs, and data model can evolve in sync.
+
+This is especially important for SaaS MVP development where founders are still testing product-market fit. If boundaries are vague, every experiment introduces accidental complexity.
+
+## 2) Define decision ownership early
+
+As teams grow, unclear decision ownership creates more risk than imperfect decisions.
+
+You need explicit answers to questions like:
+
+- Who owns pricing logic decisions?
+- Who approves interaction model changes?
+- Who decides when technical debt gets prioritized?
+- Who can override launch scope?
+
+Without this, your product roadmapping process gets slower every sprint.
+
+At 0x1 Labs, we recommend a simple decision model:
+
+- **Local decisions**: handled inside a function team (for speed)
+- **Cross-cutting decisions**: reviewed with product, design, and engineering leads
+- **Business-critical decisions**: approved by founder or accountable executive
+
+Clear ownership keeps delivery velocity high while still protecting product coherence.
+
+## 3) Build stable contracts between teams
+
+Most scaling failures are contract failures.
+
+Not legal contracts. Product contracts.
+
+Examples:
+
+- A design system contract: how reusable UI patterns should behave
+- A data contract: what each event means and how it is tracked
+- An API contract: what response guarantees frontend teams can depend on
+
+If these contracts are unstable, teams lose confidence and start adding defensive workarounds everywhere.
+
+Stable contracts do not mean frozen systems. They mean controlled change with clear versioning and communication.
+
+Practical pattern:
+
+1. Document the contract in one canonical source.
+2. Version breaking changes.
+3. Announce contract changes in release notes or sprint review.
+4. Sunset old patterns with deadlines.
+
+This improves reliability and reduces hidden rework.
+
+## 4) Design UX for changing complexity
+
+Products usually start with one user persona and one simple path. Growth introduces:
+
+- More user roles
+- More advanced settings
+- More exceptions
+- More integrations
+
+If UX structure was built only for the happy path, the interface becomes dense and confusing quickly.
+
+Designing for scale means planning how complexity will be introduced.
+
+Use these principles:
+
+- **Progressive disclosure**: hide advanced options until needed
+- **Role-aware navigation**: prioritize relevant actions per user type
+- **Reusable component logic**: keep interaction patterns consistent
+- **Context-preserving flows**: avoid forcing users to restart tasks when switching views
+
+This is one reason product studios and experienced MVP development companies often outperform task-based agencies: they design for future evolution, not just immediate launch.
+
+## 5) Architect for change frequency, not just current load
+
+Founders often ask, "Will this architecture handle 1 million users?"
+
+That is valid. But a more urgent question is:
+
+"Will this architecture support weekly product changes without breaking core workflows?"
+
+In early growth stages, change frequency is usually the harder scaling challenge than raw traffic.
+
+Design your backend around change boundaries:
+
+- Separate domains that change at different rates.
+- Avoid coupling low-change systems to high-change experiments.
+- Introduce queue/event patterns where asynchronous workflows are expected.
+- Treat analytics events as product infrastructure, not optional extras.
+
+If your team can ship safely every week, you are scaling in the dimension that matters most for startups.
+
+## 6) Make observability a feature, not an afterthought
+
+A product that "works" but cannot be diagnosed is not scalable.
+
+As soon as usage increases, you need to answer:
+
+- Where are users dropping off?
+- Which feature states produce the most support issues?
+- Which release introduced a regression?
+- Which customer segment is getting slower response times?
+
+Baseline observability stack for startup products:
+
+- Structured logs
+- Basic performance tracing
+- Error tracking with ownership routing
+- Funnel and activation dashboards
+- Release annotations tied to product metrics
+
+This creates operational confidence and shortens recovery time.
+
+## 7) Use execution loops that protect quality
+
+Scaling teams cannot rely on heroics. They need repeatable loops.
+
+A weekly operating rhythm that works well:
+
+- **Monday**: scope and risk alignment
+- **Tuesday-Wednesday**: build with focused ownership
+- **Thursday**: quality review and cross-functional QA
+- **Friday**: outcome review and release planning
+
+What matters is not the exact schedule. What matters is that quality checks are integrated into delivery, not deferred to the end.
+
+If you want a deeper breakdown, read our related guide on [execution loops](/blog/execution-loops).
+
+## 8) Avoid scaling anti-patterns early
+
+These anti-patterns look efficient in the short term but become expensive quickly:
+
+### Anti-pattern 1: "One table now, we will normalize later"
+
+This can be acceptable for prototypes, but dangerous for production MVPs. Data migration pain grows with every user and every feature.
+
+### Anti-pattern 2: "One component handles all workflows"
+
+Massive frontend components become untestable and block parallel work.
+
+### Anti-pattern 3: "We will define event names after launch"
+
+Without consistent analytics naming, you lose decision clarity and waste weeks fixing instrumentation.
+
+### Anti-pattern 4: "Release first, support manually"
+
+Manual support can hide structural UX and reliability issues. Use support feedback to improve product architecture.
+
+## 9) Connect product strategy to architecture choices
+
+Your architecture should reflect your business model.
+
+If your strategy depends on team collaboration features, design permissions and shared state models early.
+
+If your strategy depends on marketplace liquidity, prioritize trust and verification workflows.
+
+If your strategy depends on usage-based pricing, instrument value events from day one.
+
+Too many teams treat architecture as purely technical. In reality, it is strategic infrastructure.
+
+## 10) Build with scaling milestones in mind
+
+Instead of a vague "future-proof" goal, define concrete scaling milestones:
+
+- **Milestone A**: launch-ready MVP with stable core workflows
+- **Milestone B**: supports second user segment without major rewrite
+- **Milestone C**: supports team growth from 3 to 10 contributors
+- **Milestone D**: supports analytics-driven roadmap decisions
+
+Each milestone should map to intentional product and engineering decisions.
+
+This approach keeps planning realistic and prevents both under-design and over-design.
+
+## Practical checklist for founders
+
+Before your next sprint, review this checklist:
+
+1. Do we have explicit product system boundaries?
+2. Are decision owners clear for cross-functional tradeoffs?
+3. Are API/UI/data contracts documented and versioned?
+4. Can we ship weekly without recurring regressions?
+5. Do we have enough observability to debug user-facing problems quickly?
+6. Are architecture priorities tied to business outcomes, not just technical preference?
+
+If you answer "no" to more than two, your scaling risk is rising even if current metrics look healthy.
+
+## Final takeaway
+
+Designing for scale is not about building a complex system on day one.
+
+It is about making a handful of high-leverage decisions that keep your product adaptable as users, features, and team size grow.
+
+Founders who do this well create a compounding advantage: faster iteration, clearer decision-making, better product quality, and more predictable delivery.
+
+If you are planning an MVP and want to de-risk scale from the start, explore our [product strategy service](/services/product-strategy) or [MVP development approach](/services/mvp-development). You can also [contact us](/contact) for a scoped build plan.

--- a/content/blog/execution-loops.md
+++ b/content/blog/execution-loops.md
@@ -1,29 +1,229 @@
 ---
 title: "Execution Loops: Shipping Faster Without Burning Quality"
-description: "A practical sprint model for teams that need speed and reliability."
+description: "A practical operating model that helps startup teams ship weekly while preserving quality, focus, and product momentum."
 date: "2026-03-03"
 author: "0x1 Labs"
 tags:
   - Engineering
   - Delivery
+  - Product Operations
 ---
 
-Speed without quality is expensive.
+Startups usually describe their delivery problem in one of two ways:
 
-Quality without speed is irrelevant in a fast market.
+- "We are shipping quickly, but we keep breaking things."
+- "We protect quality, but we move too slowly to learn."
 
-The answer is not picking one. It is designing an execution loop where both are built into the process.
+Both are symptoms of the same issue: the team does not have a strong execution loop.
 
-## A Better Weekly Rhythm
+An execution loop is the repeatable rhythm that connects planning, building, quality control, release, and learning. When this loop is healthy, speed and quality reinforce each other instead of competing.
 
-Use short planning windows, daily alignment, and explicit scope locks. Protect engineering focus by reducing context switching and avoiding vague tickets.
+This article breaks down how to design that loop for startup product teams.
 
-## Review for Outcomes, Not Activity
+## Why most teams get stuck
 
-A strong review asks: Did we reduce risk, validate assumptions, and move the product forward?
+Many teams think they have process because they have standups, boards, and tickets. But those rituals do not guarantee execution quality.
 
-## Keep Feedback Tight
+Common failure patterns:
 
-Product, design, and engineering should close loops quickly. Fast, high-context feedback prevents drift and improves decision quality.
+- Planning based on output volume, not business outcomes
+- Tickets that define tasks but not success criteria
+- QA pushed to the end of the week
+- Releases blocked by last-minute uncertainty
+- No systematic review of what improved or regressed
 
-The goal is predictable momentum. That is what high-performing teams actually optimize for.
+Without a loop, each week feels like improvisation.
+
+## The execution loop model
+
+At a high level, a practical weekly loop has five phases:
+
+1. **Frame** the outcome
+2. **Scope** for confidence
+3. **Build** with focus
+4. **Validate** quality continuously
+5. **Review** with decision signals
+
+The key is tight handoffs between phases.
+
+## Phase 1: Frame the outcome (not just the feature)
+
+Start each sprint by defining what changes for users or the business if this work succeeds.
+
+Bad framing: "Implement billing dashboard redesign."
+
+Better framing: "Increase trial-to-paid conversion by reducing billing setup confusion."
+
+Good framing creates alignment across product, design, and engineering. It also improves prioritization when scope pressure appears mid-week.
+
+Recommended framing template:
+
+- User/problem context
+- Desired outcome metric
+- Primary risk to de-risk this sprint
+- Scope boundary for this cycle
+
+## Phase 2: Scope for confidence
+
+Scope decisions are where speed is won or lost.
+
+A common trap is packing too much into a sprint because stakeholders want certainty. Ironically, that lowers confidence because nothing is truly finished.
+
+Use confidence-based scoping:
+
+- Include only work with clear dependencies and acceptance criteria
+- Separate "must ship" from "can ship"
+- Capture unresolved questions explicitly
+- Define what will not be done this sprint
+
+When teams say no early, they ship yes more reliably.
+
+## Phase 3: Build with protected focus
+
+Execution quality depends on uninterrupted focus.
+
+Context switching is the hidden tax that destroys delivery momentum, especially in small teams.
+
+To protect build focus:
+
+- Limit parallel work in progress
+- Bundle meetings into specific windows
+- Keep one owner accountable per outcome area
+- Avoid introducing new high-risk scope after mid-sprint unless critical
+
+This is also where technical quality standards matter. Teams should agree on baseline engineering expectations before coding begins.
+
+Examples:
+
+- Definition of done includes tests and monitoring hooks
+- Pull request reviews must verify behavior and maintainability
+- Any scope requiring architectural compromise is logged as intentional debt
+
+## Phase 4: Validate continuously
+
+Quality should be a flow, not a gate.
+
+Teams that rely on end-of-week QA create bottlenecks and increase stress. Instead, validation should happen throughout the sprint.
+
+Continuous validation includes:
+
+- Product and design checks during development
+- Basic automated test coverage for critical paths
+- Regression checks on shared workflows
+- Instrumentation checks for key product events
+
+The goal is to detect issues when they are cheap to fix.
+
+If you are building an MVP, this matters even more. Early trust loss can kill adoption.
+
+## Phase 5: Review for decisions, not demos
+
+Many sprint reviews become status theater.
+
+A useful review answers five questions:
+
+1. What outcome changed this week?
+2. What risk did we reduce?
+3. What did we learn that changes next sprint?
+4. What quality concerns remain open?
+5. What should we stop doing?
+
+This review format turns weekly output into strategic learning.
+
+## Recommended weekly cadence
+
+Here is a practical cadence used by many product teams:
+
+- **Monday**: sprint framing, risk review, scope lock
+- **Tuesday-Wednesday**: focused build and async design/product checks
+- **Thursday**: integrated QA, bug triage, release prep
+- **Friday**: release, outcome review, next-sprint pre-planning
+
+Adjust as needed, but keep the loop shape stable so the team can improve it over time.
+
+## Decision loops vs task loops
+
+Fast teams optimize decision loops, not task loops.
+
+Task loop mindset: "How many tickets did we close?"
+
+Decision loop mindset: "How quickly did we make high-quality decisions with enough evidence?"
+
+Decision loops improve:
+
+- Prioritization quality
+- Release confidence
+- Product-market learning speed
+
+If your team feels busy but not effective, this is often the missing piece.
+
+## Metrics that indicate a healthy execution loop
+
+Track these signals over time:
+
+- Sprint completion confidence (committed vs shipped)
+- Defect escape rate (issues found after release)
+- Time from idea to validated outcome
+- Rework ratio (work redone due to unclear scope)
+- Change failure rate after deployments
+
+You do not need enterprise dashboards to start. A lightweight weekly scorecard is enough.
+
+## Practical anti-patterns to avoid
+
+### 1) Scope churn after kickoff
+
+Frequent scope additions are usually planning and prioritization failures, not flexibility wins.
+
+### 2) No clear acceptance criteria
+
+If acceptance criteria are vague, quality debates move to the end of the week where costs are highest.
+
+### 3) Release-only visibility
+
+If leadership sees work only at release time, strategic alignment drifts.
+
+### 4) Quality owned by one role
+
+Quality is shared responsibility across product, design, engineering, and QA.
+
+### 5) Retros with no behavior change
+
+If retrospectives do not change the loop, they become ceremonial.
+
+## Execution loops for founder-led teams
+
+Founder-led products have a unique challenge: leadership input can accelerate or destabilize execution depending on how it enters the loop.
+
+Best practice:
+
+- Reserve a specific weekly decision window for founder-level scope changes.
+- Route urgent changes through a clear triage path.
+- Keep the team protected from daily priority flips.
+
+This gives founders speed without creating delivery chaos.
+
+## How this connects to product strategy
+
+Execution loops are not just engineering mechanics. They are strategic infrastructure.
+
+A weak loop increases cost, slows validation, and makes roadmaps unreliable.
+
+A strong loop compounds advantages:
+
+- faster learning,
+- steadier releases,
+- higher trust between teams,
+- and better customer experience.
+
+If you are still shaping your product foundation, pair this operating model with a clear [founder brief](/blog/founder-brief) and explicit [product strategy](/services/product-strategy).
+
+## Final takeaway
+
+You do not need a complicated process to ship fast with quality.
+
+You need a consistent execution loop where planning, scope, build, validation, and review reinforce each other every week.
+
+That is how high-performing startup teams create predictable momentum.
+
+If your team wants help designing this loop around your MVP roadmap, explore our [MVP development service](/services/mvp-development) or [contact us](/contact) for a build planning session.

--- a/content/blog/founder-brief.md
+++ b/content/blog/founder-brief.md
@@ -1,27 +1,253 @@
 ---
 title: "The Founder Brief: What We Need Before We Build"
-description: "A concise kickoff format that saves weeks and aligns teams early."
+description: "A practical founder brief template that improves product strategy, reduces rework, and accelerates MVP execution."
 date: "2026-02-17"
 author: "0x1 Labs"
 tags:
   - Playbook
   - Founders
+  - MVP Development
 ---
 
-Most delivery problems begin before implementation.
+Most product delays are not engineering delays.
 
-If goals are unclear, teams spend time solving the wrong problem at high velocity.
+They are brief-quality delays.
 
-## The Brief We Ask For
+When startup teams begin a project without a strong founder brief, execution starts fast but drifts quickly:
 
-At minimum, define user, business objective, constraints, and success metrics. This removes ambiguity and accelerates useful execution.
+- Product and engineering interpret priorities differently.
+- Scope expands because constraints were not explicit.
+- Teams ship features that do not move the core business metric.
+- Rework consumes the budget intended for growth.
 
-## Clarify What Is Non-Negotiable
+The founder brief exists to prevent this.
 
-Every product has a few hard constraints. List them early. They shape architecture, roadmap, and delivery decisions.
+It is not a long strategy deck. It is a practical document that aligns decision-makers before build work begins.
 
-## Make Success Measurable
+This guide explains what a high-quality founder brief includes, why it matters for MVP development, and how to use it as an execution tool.
 
-Use one primary metric and a small supporting set. Teams move better when they know exactly what outcome they are accountable for.
+## What a founder brief is (and is not)
 
-A strong brief is leverage. It aligns everyone before the first line of code.
+A founder brief is:
+
+- A decision document for product direction
+- A scope and risk alignment tool
+- A source of truth for outcomes and constraints
+
+It is not:
+
+- A generic company overview
+- A list of every possible feature idea
+- A static artifact that never changes
+
+The right brief should be concise but complete enough for product, design, and engineering to make consistent decisions.
+
+## Why this matters for startup products
+
+In early-stage teams, execution capacity is limited.
+
+Every sprint invested in the wrong direction carries opportunity cost. A high-quality founder brief increases the probability that your first build cycles produce useful learning and business movement.
+
+Benefits of a strong brief:
+
+- Faster onboarding of contributors
+- Better roadmap prioritization
+- Lower rework from scope confusion
+- Higher confidence in architecture decisions
+- Clearer communication with investors and stakeholders
+
+If you are comparing a product studio vs agency vs freelancer model, this document is also your baseline for evaluating delivery partners.
+
+## The core sections every founder brief needs
+
+Below is the minimum useful structure.
+
+## 1) Problem statement
+
+Describe the problem in user and business terms.
+
+Weak version:
+
+"We need a modern platform for creators."
+
+Strong version:
+
+"Independent creators lose paid opportunities because booking, scheduling, and payment workflows are fragmented. We need one reliable workflow that reduces drop-off from inquiry to confirmed booking."
+
+A strong problem statement helps teams avoid building cosmetic features that do not solve the root issue.
+
+## 2) Primary user and buyer context
+
+Define who the product is for and who pays.
+
+Include:
+
+- Primary user persona
+- Secondary user persona (if relevant)
+- Buyer/decision-maker profile
+- Existing alternatives users rely on today
+
+Without this section, teams often optimize for the wrong experience.
+
+## 3) Business objective
+
+What is the business outcome this project must unlock?
+
+Examples:
+
+- Validate demand for a paid workflow
+- Improve conversion from trial to paid
+- Reduce onboarding abandonment
+- Enable sales team demos with a stable MVP
+
+Your business objective should guide tradeoffs when timeline pressure appears.
+
+## 4) Success metrics
+
+Use one primary metric and two to four supporting metrics.
+
+Example:
+
+- Primary: activation rate from signup to first key action
+- Supporting: onboarding completion time, weekly retention, support tickets per active user
+
+Metrics keep execution focused on outcomes instead of output volume.
+
+## 5) Scope boundaries
+
+A brief without boundaries is a wish list.
+
+Clearly define:
+
+- Must-have capabilities for v1
+- Nice-to-have capabilities for later phases
+- Explicitly out-of-scope items
+
+This reduces scope creep and improves sprint planning quality.
+
+## 6) Non-negotiable constraints
+
+Every product has constraints. Good teams surface them early.
+
+Common constraints:
+
+- Compliance and security requirements
+- Budget limits
+- Launch deadline tied to funding/sales commitments
+- Technical integration dependencies
+- Brand/legal requirements
+
+When constraints are hidden, architecture and roadmap decisions become fragile.
+
+## 7) Product assumptions and risks
+
+List assumptions that could invalidate your plan.
+
+Examples:
+
+- Users will trust self-serve onboarding without sales assistance
+- Existing CRM integration is stable enough for launch timeline
+- Pricing model will not create support burden
+
+Each assumption should map to a validation plan.
+
+## 8) Execution model
+
+Include a short section on how decisions and delivery will run:
+
+- Who signs off on scope decisions
+- Weekly review cadence
+- How blockers are escalated
+- Release and QA expectations
+
+This directly improves your [execution loops](/blog/execution-loops).
+
+## Founder brief template (copy/paste)
+
+You can use this exact skeleton for kickoff:
+
+1. Product name and one-line vision
+2. Problem statement
+3. Primary user and buyer profile
+4. Business objective for this phase
+5. Primary and supporting success metrics
+6. Must-have scope for v1
+7. Out-of-scope for this phase
+8. Constraints and dependencies
+9. Key assumptions and validation plan
+10. Execution cadence and decision owners
+
+If this feels difficult to complete, that itself is a signal you need pre-build strategy work.
+
+## Common founder brief mistakes
+
+### Mistake 1: Feature-heavy, outcome-light
+
+Long feature lists without business outcomes create implementation noise.
+
+### Mistake 2: No clear "not now" list
+
+Without an explicit out-of-scope section, every stakeholder assumes their request is in scope.
+
+### Mistake 3: Vague success metrics
+
+"Improve engagement" is not actionable. Define measurable targets.
+
+### Mistake 4: Ignoring internal constraints
+
+If your team can only support one release per week, your roadmap must reflect that reality.
+
+### Mistake 5: Treating the brief as final forever
+
+The brief should evolve based on learning, but through intentional updates, not random Slack threads.
+
+## How a strong brief changes engineering quality
+
+Engineering quality starts with product clarity.
+
+When requirements are ambiguous, teams either overbuild "just in case" or underbuild with fragile assumptions.
+
+A clear brief improves technical decisions:
+
+- Better data model planning
+- Clearer API contract choices
+- More accurate testing scope
+- Fewer emergency rewrites
+
+This is one reason mature MVP development companies ask for structured briefs before quoting build phases.
+
+## How to use the brief during delivery
+
+Do not archive the brief after kickoff.
+
+Use it every sprint:
+
+- Validate that current tickets support the primary outcome
+- Review whether assumptions have changed
+- Track metric movement against planned success criteria
+- Update constraints when business conditions change
+
+Think of the brief as the control panel for strategic execution.
+
+## Founder brief and investor communication
+
+A clear brief also improves external communication.
+
+For investor updates, it helps you explain:
+
+- Why the roadmap is structured the way it is
+- What milestones indicate progress
+- Which risks are actively managed
+- How resources map to outcomes
+
+That level of clarity builds credibility.
+
+## Final takeaway
+
+The founder brief is one of the highest-leverage tools in startup product development.
+
+It creates alignment before code, protects delivery quality during sprints, and improves decision-making as the product evolves.
+
+If your team is preparing for an MVP launch, start with a structured brief, then align it with your [product strategy phase](/services/product-strategy) and [MVP development plan](/services/mvp-development).
+
+Need help writing or pressure-testing your brief? [Contact 0x1 Labs](/contact) and we will help you turn it into a build-ready plan.

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,29 @@
+export const siteName = '0x1 Labs'
+export const siteUrl = 'https://www.0x1labs.com'
+
+export const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: siteName,
+  url: siteUrl,
+  logo: `${siteUrl}/android-chrome-512x512.png`,
+  email: 'hello@0x1labs.com',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Kathmandu',
+    addressCountry: 'NP',
+  },
+}
+
+export function breadcrumbJsonLd(items: Array<{ name: string; path: string }>) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: `${siteUrl}${item.path}`,
+    })),
+  }
+}


### PR DESCRIPTION
## Summary
- establish technical SEO foundations with stronger global metadata, canonical/robots controls, and generated `robots.txt` + `sitemap.xml`
- expand site architecture with dedicated crawlable pages for about, services, work case studies, contact, faq, privacy, and terms
- improve page-level metadata and schema coverage (Organization, Article, JobPosting hardening, Service, FAQPage, BreadcrumbList) and update navigation/internal linking away from hash-only routes
- rewrite blog content into long-form SEO articles and simplify the contact intake form to required name/email/idea plus optional phone

## Validation
- `npm run build`