### PR TITLE
Refine FormEasy project inquiry flow and scheduling links

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
+import ProjectInquiryForm from '@/components/ProjectInquiryForm'
 import { breadcrumbJsonLd, siteUrl } from '@/lib/seo'
 
 export const metadata: Metadata = {
@@ -34,7 +35,7 @@ export default function ContactPage() {
             email hello@0x1labs.com.
           </p>
           <div className="mt-5 flex flex-wrap gap-3">
-            <a href="https://calendly.com" className="btn-primary">Book a free discovery call</a>
+            <a href="https://calendly.com/0x1labs0x1/30min" className="btn-primary">Book a free discovery call</a>
             <a href="mailto:hello@0x1labs.com" className="btn-secondary">Email the team</a>
           </div>
         </div>
@@ -42,28 +43,7 @@ export default function ContactPage() {
 
       <section className="content-wrap py-10 md:py-14">
         <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-          <form
-            className="rounded-2xl border border-white/15 bg-white/[0.04] p-6 md:p-8"
-            action="mailto:hello@0x1labs.com"
-            method="post"
-            encType="text/plain"
-          >
-            <h2 className="text-white">Start a project</h2>
-            <p className="mt-2 text-sm text-zinc-400">Share your idea and we will follow up with next steps.</p>
-            <div className="mt-5 grid gap-4 md:grid-cols-2">
-              <input name="name" placeholder="Your name" required className="rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100" />
-              <input name="email" type="email" placeholder="Work email" required className="rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100" />
-              <input name="phone" type="tel" placeholder="Phone number (optional)" className="rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100 md:col-span-2" />
-            </div>
-            <textarea
-              name="idea"
-              rows={6}
-              placeholder="Tell us your idea"
-              className="mt-4 w-full rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100"
-              required
-            />
-            <button type="submit" className="btn-primary mt-5">Send project inquiry</button>
-          </form>
+          <ProjectInquiryForm />
 
           <aside className="space-y-4">
             <div className="rounded-2xl border border-white/15 bg-white/[0.04] p-6">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ const spaceGrotesk = Space_Grotesk({
 
 export const metadata: Metadata = {
   title: {
-    default: '0x1 Labs - Product Studio for Founders | MVP Development and Strategy',
+    default: '0x1 Labs | Product Studio for Founders and MVP Builds',
     template: '%s | 0x1 Labs',
   },
   description:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -357,7 +357,7 @@ export default function Home() {
               <Link href="/contact" className="btn-primary">
                 Open Contact Form
               </Link>
-              <a href="https://calendly.com" className="btn-secondary">
+              <a href="https://calendly.com/0x1labs0x1/30min" className="btn-secondary">
                 Book Discovery Call
               </a>
             </div>

--- a/components/ProjectInquiryForm.tsx
+++ b/components/ProjectInquiryForm.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useState } from 'react'
+
+type FormState = {
+  name: string
+  email: string
+  message: string
+}
+
+const initialState: FormState = {
+  name: '',
+  email: '',
+  message: '',
+}
+
+const ProjectInquiryForm = () => {
+  const [formData, setFormData] = useState<FormState>(initialState)
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setLoading(true)
+    setMessage(null)
+
+    const url = process.env.NEXT_PUBLIC_APP_SCRIPT_URL
+
+    if (!url) {
+      setMessage({
+        type: 'error',
+        text: 'Form submission failed: NEXT_PUBLIC_APP_SCRIPT_URL is missing.',
+      })
+      setLoading(false)
+      return
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/plain;charset=utf-8',
+        },
+        body: JSON.stringify(formData),
+      })
+
+      if (!response.ok) {
+        throw new Error('Submission failed')
+      }
+
+      setMessage({
+        type: 'success',
+        text: 'Thank you. We received your inquiry and will get back to you shortly.',
+      })
+      setFormData(initialState)
+    } catch {
+      setMessage({
+        type: 'error',
+        text: 'Form submission failed. Please try again or email hello@0x1labs.com.',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form className="rounded-2xl border border-white/15 bg-white/[0.04] p-6 md:p-8" onSubmit={handleSubmit}>
+      <h2 className="text-white">Start a project</h2>
+      <p className="mt-2 text-sm text-zinc-400">Send a quick message and we will follow up with next steps.</p>
+      <p className="mt-1 text-xs text-zinc-500">Required fields: Name, Email, Message.</p>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        <input
+          name="name"
+          placeholder="Your name"
+          value={formData.name}
+          onChange={handleChange}
+          required
+          disabled={loading}
+          className="rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100 disabled:opacity-50"
+        />
+        <input
+          name="email"
+          type="email"
+          placeholder="Work email"
+          value={formData.email}
+          onChange={handleChange}
+          required
+          disabled={loading}
+          className="rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100 disabled:opacity-50"
+        />
+      </div>
+
+      <textarea
+        name="message"
+        rows={6}
+        placeholder="Tell us your message"
+        value={formData.message}
+        onChange={handleChange}
+        required
+        disabled={loading}
+        className="mt-4 w-full rounded-xl border border-white/20 bg-black/40 px-4 py-3 text-zinc-100 disabled:opacity-50"
+      />
+
+      <button type="submit" disabled={loading} className="btn-primary mt-5 disabled:opacity-50">
+        {loading ? 'Sending...' : 'Send project inquiry'}
+      </button>
+
+      {message && (
+        <p
+          className={`mt-4 rounded-xl border px-4 py-3 text-sm ${
+            message.type === 'success'
+              ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200'
+              : 'border-red-400/40 bg-red-500/10 text-red-200'
+          }`}
+        >
+          {message.text}
+        </p>
+      )}
+    </form>
+  )
+}
+
+export default ProjectInquiryForm


### PR DESCRIPTION
## Summary
- replace the mailto contact form with a client-side FormEasy submission component using `NEXT_PUBLIC_APP_SCRIPT_URL`
- simplify submission fields to Name, Email, and Message only to match supported FormEasy payload fields
- update Calendly links to `https://calendly.com/0x1labs0x1/30min`
- shorten the default homepage title tag for improved SEO title length

## Validation
- npm run build